### PR TITLE
Refactor tasks state register

### DIFF
--- a/firmware/inc/cuttlefish_fip_app.h
+++ b/firmware/inc/cuttlefish_fip_app.h
@@ -28,7 +28,7 @@ extern HarpCApp& app;
 #pragma pack(push, 1)
 struct app_regs_t
 {
-    uint8_t EnableTaskSchedule;
+    uint8_t SetTasksState;
     LaserFIPTaskSettings AddLaserTask;
     uint8_t RemoveLaserTask;
     uint8_t RemoveAllLaserTasks;
@@ -41,7 +41,7 @@ struct app_regs_t
 
 enum AppRegNum
 {
-    EnableTaskSchedule = 32,
+    SetTasksState = 32,
     AddLaserTask = 33,
     RemoveLaserTask = 34,
     RemoveAllLaserTasks = 35,
@@ -56,6 +56,13 @@ enum AppRegNum
     ReconfigureLaserTask6 = 44,
     ReconfigureLaserTask7 = 45,
 
+};
+
+enum TasksState
+{
+    Start = 0x01,
+    Stop = 0x00,
+    Abort = 0x02,
 };
 
 extern app_regs_t app_regs;
@@ -73,18 +80,18 @@ inline size_t get_fip_task_index(msg_t& msg)
 {return msg.header.address - LASER_BASE_ADDRESS;}
 
 /**
- * \brief set waveform output to enabled or disabled, but do not destroy tasks.
+ * \brief Start, stop or abort waveform output tasks, but do not destroy tasks.
  * Also update the Harp register representation of the task schedule state.
  * \return whether or not the state change was successful.
  */
-bool set_task_schedule_state(bool state);
+bool set_task_schedule_state(uint8_t state);
 
 /**
  * \brief read whether the laser task schedule is enabled or not.
  */
 void read_reconfigure_laser_task(uint8_t address);
 
-void write_enable_task_schedule(msg_t& msg);
+void write_set_tasks_state(msg_t& msg);
 void write_add_laser_task(msg_t& msg);
 void write_remove_laser_task(msg_t& msg);
 void write_remove_all_laser_tasks(msg_t& msg);

--- a/firmware/inc/fip_ctrl_queues.h
+++ b/firmware/inc/fip_ctrl_queues.h
@@ -18,7 +18,7 @@ struct RisingEdgeEventData
 };
 
 // Queues for multicore communication.
-extern queue_t enable_task_schedule_queue;
+extern queue_t set_tasks_state_queue;
 extern queue_t add_task_queue;
 extern queue_t remove_task_queue;
 extern queue_t clear_tasks_queue;

--- a/firmware/inc/fip_schedule.h
+++ b/firmware/inc/fip_schedule.h
@@ -34,7 +34,7 @@ extern bool enabled;
  */
 void run();
 
-void update_enabled_state();
+void update_tasks_state();
 
 inline void update_fip_tasks();
 

--- a/firmware/src/cuttlefish_fip_app.cpp
+++ b/firmware/src/cuttlefish_fip_app.cpp
@@ -220,7 +220,7 @@ void update_app()
     }
     // Disable output waveforms if we've disconnected com ports (safety feature).
     if (HarpCore::get_op_mode() != ACTIVE)
-        set_task_schedule_state(0x00);
+        set_task_schedule_state(TasksState::Abort);
 }
 
 void reset_app()

--- a/firmware/src/fip_schedule.cpp
+++ b/firmware/src/fip_schedule.cpp
@@ -2,6 +2,7 @@
 #include <fip_schedule.h>
 #include <fip_ctrl_queues.h>
 #include <hardware/structs/timer.h>
+#include <cuttlefish_fip_app.h>
 
 etl::vector<LaserFIPTask, MAX_TASK_COUNT> fip_tasks;
 
@@ -40,7 +41,7 @@ void update_tasks_state()
         if (queue_try_remove(&set_tasks_state_queue, &tasks_state))
         {
             // Update the enabled state based on the message.
-            if (tasks_state == 1)
+            if (tasks_state == uint8_t(TasksState::Start)) // If the state is set to "Start".
             {
                 enabled = true;
                 abort_requested = false;
@@ -49,7 +50,7 @@ void update_tasks_state()
             {
                 enabled = false;
 
-                if (tasks_state == 2) // If the state is set to "Abort".
+                if (tasks_state == uint8_t(TasksState::Abort)) // If the state is set to "Abort".
                     abort_requested = true;
             }
         }

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -9,7 +9,7 @@
 #include <hardware/structs/bus_ctrl.h>
 #include <core1_main.h>
 
-queue_t enable_task_schedule_queue;
+queue_t set_tasks_state_queue;
 queue_t add_task_queue;
 queue_t remove_task_queue;
 queue_t clear_tasks_queue;
@@ -47,7 +47,7 @@ int main()
     // Configure core1 to have high bus priority.
     bus_ctrl_hw->priority = 0x00000010;
     // Initialize queues for multicore communication.
-    queue_init(&enable_task_schedule_queue, sizeof(uint8_t), MAX_QUEUE_SIZE);
+    queue_init(&set_tasks_state_queue, sizeof(uint8_t), MAX_QUEUE_SIZE);
     queue_init(&add_task_queue, sizeof(LaserFIPTaskSettings), MAX_QUEUE_SIZE);
     queue_init(&remove_task_queue, sizeof(uint8_t), MAX_QUEUE_SIZE);
     queue_init(&clear_tasks_queue, sizeof(uint8_t), MAX_QUEUE_SIZE);

--- a/software/pyharp/app_registers.py
+++ b/software/pyharp/app_registers.py
@@ -3,7 +3,7 @@ from enum import IntEnum
 
 
 class AppRegs(IntEnum):
-    EnableTaskSchedule = 32
+    SetTasksState = 32
     AddLaserTask = 33
     RemoveLaserTask = 34
     RemoveAllLaserTasks = 35

--- a/software/pyharp/configure_and_check_tasks.py
+++ b/software/pyharp/configure_and_check_tasks.py
@@ -79,7 +79,7 @@ def configure_tasks(device):
     data_fmt = "<LffLBBLLLL"
 
     print("\nDisabling schedule.")
-    device.send(WriteU8HarpMessage(AppRegs.EnableTaskSchedule, 0).frame)
+    device.send(WriteU8HarpMessage(AppRegs.SetTasksState, 0).frame)
     print("\nClearing all tasks.")
     device.send(WriteU8HarpMessage(AppRegs.RemoveAllLaserTasks, 1).frame)
 

--- a/software/pyharp/send_fip_waveform.py
+++ b/software/pyharp/send_fip_waveform.py
@@ -41,7 +41,7 @@ settings = \
 data_fmt = "<LffLBBLLLL"
 
 print("Disabling schedule.")
-device.send(WriteU8HarpMessage(AppRegs.EnableTaskSchedule, 0).frame)
+device.send(WriteU8HarpMessage(AppRegs.SetTasksState, 0).frame)
 print("Clearing all tasks.")
 device.send(WriteU8HarpMessage(AppRegs.RemoveAllLaserTasks, 1).frame)
 
@@ -49,8 +49,8 @@ print("Configuring device with FIP task.")
 measurement = device.send(WriteU8ArrayMessage(AppRegs.AddLaserTask,
                                               data_fmt, settings).frame)
 print("Enabling schedule")
-device.send(WriteU8HarpMessage(AppRegs.EnableTaskSchedule, 1).frame)
+device.send(WriteU8HarpMessage(AppRegs.SetTasksState, 1).frame)
 sleep(3)
 
 print("Disabling schedule.")
-device.send(WriteU8HarpMessage(AppRegs.EnableTaskSchedule, 0).frame)
+device.send(WriteU8HarpMessage(AppRegs.SetTasksState, 0).frame)

--- a/software/pyharp/send_fip_waveform_and_disconnect.py
+++ b/software/pyharp/send_fip_waveform_and_disconnect.py
@@ -41,7 +41,7 @@ settings = \
 data_fmt = "<LffLBBLLLL"
 
 print("Disabling schedule.")
-device.send(WriteU8HarpMessage(AppRegs.EnableTaskSchedule, 0).frame)
+device.send(WriteU8HarpMessage(AppRegs.SetTasksState, 0).frame)
 print("Clearing all tasks.")
 device.send(WriteU8HarpMessage(AppRegs.RemoveAllLaserTasks, 1).frame)
 
@@ -49,7 +49,7 @@ print("Configuring device with FIP task.")
 measurement = device.send(WriteU8ArrayMessage(AppRegs.AddLaserTask,
                                               data_fmt, settings).frame)
 print("Enabling schedule")
-device.send(WriteU8HarpMessage(AppRegs.EnableTaskSchedule, 1).frame)
+device.send(WriteU8HarpMessage(AppRegs.SetTasksState, 1).frame)
 sleep(1)
 
 print("Disconnecting. Device should kill waveform in 3 seconds.")

--- a/software/pyharp/send_fip_waveform_and_get_events.py
+++ b/software/pyharp/send_fip_waveform_and_get_events.py
@@ -41,7 +41,7 @@ settings = \
 data_fmt = "<LffLBBLLLL"
 
 print("Disabling schedule.")
-device.send(WriteU8HarpMessage(AppRegs.EnableTaskSchedule, 0).frame)
+device.send(WriteU8HarpMessage(AppRegs.SetTasksState, 0).frame)
 print("Clearing all tasks.")
 device.send(WriteU8HarpMessage(AppRegs.RemoveAllLaserTasks, 1).frame)
 
@@ -49,7 +49,7 @@ print("Configuring device with FIP task.")
 measurement = device.send(WriteU8ArrayMessage(AppRegs.AddLaserTask,
                                               data_fmt, settings).frame)
 print("Enabling schedule")
-device.send(WriteU8HarpMessage(AppRegs.EnableTaskSchedule, 1).frame)
+device.send(WriteU8HarpMessage(AppRegs.SetTasksState, 1).frame)
 
 start_time_s = perf_counter()
 while (perf_counter() - start_time_s) < 3:
@@ -58,4 +58,4 @@ while (perf_counter() - start_time_s) < 3:
         print()
 
 print("Disabling schedule.")
-device.send(WriteU8HarpMessage(AppRegs.EnableTaskSchedule, 0).frame)
+device.send(WriteU8HarpMessage(AppRegs.SetTasksState, 0).frame)

--- a/software/pyharp/send_fip_waveform_and_measure_time_delta.py
+++ b/software/pyharp/send_fip_waveform_and_measure_time_delta.py
@@ -37,7 +37,7 @@ def send_fip_waveform(device):
     data_fmt = "<LffLBBLLLL"
 
     print("Disabling schedule.")
-    device.send(WriteU8HarpMessage(AppRegs.EnableTaskSchedule, 0).frame)
+    device.send(WriteU8HarpMessage(AppRegs.SetTasksState, 0).frame)
     print("Clearing all tasks.")
     device.send(WriteU8HarpMessage(AppRegs.RemoveAllLaserTasks, 1).frame)
 
@@ -45,12 +45,12 @@ def send_fip_waveform(device):
     device.send(WriteU8ArrayMessage(AppRegs.AddLaserTask, data_fmt, settings).frame)
 
     print("Enabling schedule.")
-    device.send(WriteU8HarpMessage(AppRegs.EnableTaskSchedule, 1).frame)
+    device.send(WriteU8HarpMessage(AppRegs.SetTasksState, 1).frame)
     
     sleep(3)
 
     print("Disabling schedule.")
-    device.send(WriteU8HarpMessage(AppRegs.EnableTaskSchedule, 0).frame)
+    device.send(WriteU8HarpMessage(AppRegs.SetTasksState, 0).frame)
 
 # Function to listen for rising edge events
 def listen_for_events(device):

--- a/software/pyharp/send_fip_waveform_and_measure_time_delta.py
+++ b/software/pyharp/send_fip_waveform_and_measure_time_delta.py
@@ -20,13 +20,12 @@ def find_device():
             return Device(port)
     raise Exception("Device not found.")
 
-# Function to send FIP waveform settings
-def send_fip_waveform(device):
-    settings = (
+
+settings = (
         0b00000001,   # pwm_pin
-        0.5, # pwm duty cycle
-        10000., # pwm frequency (hz)
-        0b00000010, # output mask
+        0.5,  # pwm duty cycle
+        10000.,  # pwm frequency (hz)
+        0b00000010,  # output mask
         1,      # events
         0,      # mute
         15350,  # DELTA1
@@ -34,6 +33,11 @@ def send_fip_waveform(device):
         600,    # DELTA3
         50     # DELTA4
     )
+
+
+# Function to send FIP waveform settings
+def send_fip_waveform(device):
+
     data_fmt = "<LffLBBLLLL"
 
     print("Disabling schedule.")
@@ -46,16 +50,18 @@ def send_fip_waveform(device):
 
     print("Enabling schedule.")
     device.send(WriteU8HarpMessage(AppRegs.SetTasksState, 1).frame)
-    
+
     sleep(3)
 
     print("Disabling schedule.")
     device.send(WriteU8HarpMessage(AppRegs.SetTasksState, 0).frame)
 
+
 # Function to listen for rising edge events
 def listen_for_events(device):
     print("Listening for rising edge events from core 0...")
     event_times = collections.deque(maxlen=10)  # Store last 10 timestamps
+    counter = 0
 
     while True:
         messages = device.get_events()
@@ -64,13 +70,20 @@ def listen_for_events(device):
             if message._timestamp is not None:
                 timestamp = message._timestamp
                 event_times.append(timestamp)
+                counter += 1
                 if len(event_times) >= 2:
                     delta = event_times[-1] - event_times[-2]
-                    print(f"Rising edge at {timestamp} s, Δt = {delta * 1e6:.2f} µs")
+                    if counter % 2 == 0:
+                        nominal = settings[8]
+                        print(f"Rising edge at {timestamp:.6f} s, Δt = {delta * 1e6:.2f} µs, nominal = {nominal} µs, error = {abs(delta * 1e6 - nominal):.2f} µs")
+                    else:
+                        nominal = settings[6] + settings[7] + settings[9]
+                        print(f"Rising edge at {timestamp:.6f} s, Δt = {delta * 1e6:.2f} µs, nominal = {nominal} µs, error = {abs(delta * 1e6 - nominal):.2f} µs")
                 else:
                     print(f"First Rising edge at {timestamp} us")
-            
+
             print()
+
 
 if __name__ == "__main__":
     try:

--- a/software/pyharp/send_many_fip_waveforms.py
+++ b/software/pyharp/send_many_fip_waveforms.py
@@ -69,7 +69,7 @@ settings = \
 data_fmt = "<LffLBBLLLL"
 
 print("Disabling schedule.")
-device.send(WriteU8HarpMessage(AppRegs.EnableTaskSchedule, 0).frame)
+device.send(WriteU8HarpMessage(AppRegs.SetTasksState, 0).frame)
 print("Clearing all tasks.")
 device.send(WriteU8HarpMessage(AppRegs.RemoveAllLaserTasks, 1).frame)
 sleep(0.1)
@@ -84,8 +84,8 @@ for index, settings in enumerate(settings):
     sleep(0.1)
 for i in range(2):
     print("Enabling schedule")
-    device.send(WriteU8HarpMessage(AppRegs.EnableTaskSchedule, 1).frame)
+    device.send(WriteU8HarpMessage(AppRegs.SetTasksState, 1).frame)
     sleep(0.5)
     print("Disabling schedule.")
-    device.send(WriteU8HarpMessage(AppRegs.EnableTaskSchedule, 0).frame)
+    device.send(WriteU8HarpMessage(AppRegs.SetTasksState, 0).frame)
     sleep(0.5)

--- a/software/pyharp/stop_vs_abort_tasks.py
+++ b/software/pyharp/stop_vs_abort_tasks.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+from pyharp.device import Device, DeviceMode
+from pyharp.messages import WriteU8HarpMessage, WriteU8ArrayMessage, ReadU8HarpMessage
+from pyharp.messages import MessageType
+from pyharp.messages import CommonRegisters as Regs
+from app_registers import AppRegs
+from time import sleep
+import serial.tools.list_ports
+import threading
+import sys
+import collections
+
+# Function to find and connect to the device
+def find_device():
+    ports = serial.tools.list_ports.comports()
+    for port, desc, hwid in sorted(ports):
+        if port.startswith("/dev/ttyUSB0") or port.startswith("/dev/ttyACM0") or port.startswith("COM5"):  
+            return Device(port)
+        elif desc.startswith("cuttlefish-fip"):
+            return Device(port)
+    raise Exception("Device not found.")
+
+# Function to send FIP waveform settings
+def send_fip_waveform(device):
+    settings = (
+        0b00000001,   # pwm_pin
+        0.5, # pwm duty cycle
+        10000., # pwm frequency (hz)
+        0b00000010, # output mask
+        1,      # events
+        0,      # mute
+        2000000,  # DELTA1
+        666,    # DELTA2
+        5000000,    # DELTA3
+        50     # DELTA4
+    )
+    data_fmt = "<LffLBBLLLL"
+
+    print("*********** Disabling schedule ***********")
+    device.send(WriteU8HarpMessage(AppRegs.SetTasksState, 0).frame)
+
+    print("*********** Clearing all tasks ***********")
+    device.send(WriteU8HarpMessage(AppRegs.RemoveAllLaserTasks, 1).frame)
+
+    print("*********** Configuring device with FIP task ***********")
+    device.send(WriteU8ArrayMessage(AppRegs.AddLaserTask, data_fmt, settings).frame)
+
+    print("*********** Enabling schedule ***********")
+    device.send(WriteU8HarpMessage(AppRegs.SetTasksState, 1).frame)
+
+    sleep(2)
+
+    print("*********** Aborting schedule ***********")
+    reply = device.send(WriteU8HarpMessage(AppRegs.SetTasksState, 0x02).frame)
+    print(reply)
+
+    print("*********** Clearing all tasks ***********")
+    reply = device.send(WriteU8HarpMessage(AppRegs.RemoveAllLaserTasks, 1).frame)
+    print(reply)
+
+    print("*********** Re-Configuring device with FIP task ***********")
+    reply = device.send(WriteU8ArrayMessage(AppRegs.AddLaserTask, data_fmt, settings).frame)
+    print(reply)
+
+    print("*********** Re-Enabling schedule again ***********")
+    reply = device.send(WriteU8HarpMessage(AppRegs.SetTasksState, 1).frame)
+    print(reply)
+
+    sleep(2)
+
+    print("*********** Stopping schedule ***********")
+    reply = device.send(WriteU8HarpMessage(AppRegs.SetTasksState, 0x00).frame)
+    print(reply)
+
+
+# Function to listen for rising edge events
+def listen_for_events(device):
+    print("Listening for rising edge events from core 0...")
+    event_times = collections.deque(maxlen=10)  # Store last 10 timestamps
+
+    while True:
+        messages = device.get_events()
+        for message in messages:
+            # Assume message contains a 'timestamp' field in seconds
+            if message._timestamp is not None:
+                timestamp = message._timestamp
+                event_times.append(timestamp)
+                if len(event_times) >= 2:
+                    delta = event_times[-1] - event_times[-2]
+                    print(f"Rising edge at {timestamp} s, Δt = {delta * 1e6:.2f} µs")
+                else:
+                    print(f"First Rising edge at {timestamp} s")
+            
+            print()
+
+if __name__ == "__main__":
+    try:
+        device = find_device()
+        device.info()
+
+        # Create and start a thread for event listening
+        event_thread = threading.Thread(target=listen_for_events, args=(device,))
+        event_thread.daemon = True  # Thread will exit when main program exits
+        event_thread.start()
+
+        send_fip_waveform(device)
+
+        # press Ctrl+C stop the script
+        while True:
+            sleep(1)  # Keep the main thread alive to allow event listening
+
+    except Exception as e:
+        print("An error occurred:", e)


### PR DESCRIPTION
Closes #7 

The changes in this PR add support for three task states (`Start`, `Stop`, and `Abort`) to enhance task management functionality.

* Replaced `EnableTaskSchedule` with `SetTasksState` in the firmware. Added a new `TasksState` enum to define task states (`Start`, `Stop`, `Abort`)
  * `Abort` - any running tasks are cancelled immediately and ensures that all outputs are disabled. 
  * `Stop` - any running tasks are allowed to finish running their exposure cycle and then stopped.
* Updated the `set_task_schedule_state` function to handle the new task states and reflect changes in the `SetTasksState` register.
* Updated Python scripts to use `SetTasksState` instead of `EnableTaskSchedule` for setting task states. This change affects all scripts interacting with the task scheduling system.
* Added a new test for verifying aborting tasks